### PR TITLE
Add minutes for swc-lpgc meeting - Nov 18, 2025

### DIFF
--- a/minutes/2025/2025-11-18Minutes.md
+++ b/minutes/2025/2025-11-18Minutes.md
@@ -109,7 +109,7 @@ Deferred to the next meeting due to time.
 
 A link was shared for future discussion: [https://github.com/carpentries-lab/reviews/issues/33](https://github.com/carpentries-lab/reviews/issues/33)
 
-Time did not allow for a *detailed* discussion.
+Time did not allow for a *detailed* discussion but no immediate follow up is required.
 
 ## **Action Items**
 


### PR DESCRIPTION
*Summary*
This pull request adds the minutes from the 18 Nov 2025 Software Carpentry Governance Committee meeting. The document follows the established format used in previous minutes and incorporates notes captured during the meeting.

*Reason for changes*
Well… I’m the secretary, so this is me doing my job 😄
Also, to maintain an up-to-date public record of committee activities and discussions, and to ensure transparency and continuity across meetings.

*Related discussions*
All notes were extracted from the [Etherpad](https://pad.carpentries.org/swc-lpgc-meetings) we used during the meeting.

Thank you (in advance) for the review!

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
