### PR TITLE
Add minutes for swc-lpgc meeting - Dec 16, 2025

### DIFF
--- a/minutes/2025/2025-12-16Minutes.md
+++ b/minutes/2025/2025-12-16Minutes.md
@@ -1,0 +1,83 @@
+# **Minutes – December 16, 2025**
+
+## **Attendees**
+
+* Sarah Stevens (Chair)
+* Deborah “Debs” Udoh (Secretary)
+* Magnus Hagdorn
+* Annajiat Alim Rasel
+* Martino Sorbaro
+* Erin Becker
+* Toby Hodges (Director of Curriculum, The Carpentries)
+
+## **Agenda**
+1. Welcome & introductions
+2. Visioning exercise (continuation)
+3. Goals for the next 3–5 years
+4. Term lengths for committee members
+
+## **Notes**
+
+### **1. Welcome & Introductions**
+Brief welcome to participants.
+
+### **2. Visioning Exercise (Continuation)**
+A summary of the previous meeting’s visioning discussion was reviewed (see [2025-11-18Minutes](https://github.com/swcarpentry/governance/blob/main/minutes/2025/2025-11-18Minutes.md)).
+
+#### **Git lesson and platforms discussion**
+
+* **Magnus** raised concerns about reliance on GitHub, noting its centralising nature and questioning whether SWC should take a clearer values-based stance versus a pragmatic one.
+* **Sarah** noted that the current Git lesson is largely platform-agnostic and suggested offering learners choices of hosting platforms. She also acknowledged growing interest in graphical-first or GitHub-web-interface-only approaches.
+* **Martino** referenced a previous idea of splitting content into a “Git only” lesson and a separate “GitHub/forge-specific” lesson.
+* **Magnus** highlighted similar concerns with the increasing use of VS Code in intermediate workshops and questioned the sustainability of supporting multiple tools.
+* **Sarah** suggested polling the community to understand which alternative hosting services would be most welcome.
+
+The group agreed these topics require further, dedicated discussion over time.
+
+### **3. What New Things Would You Like to See in SWC by 2030?**
+
+* Development of more “next-step” and intermediate lessons, many of which already exist in the Incubator (Magnus).
+* Lessons on reproducible workflows, reporting and document production, and ML/AI, with awareness that some content may later fit better in a different lesson program (Sarah).
+* More proactive, holistic updates to existing lessons rather than only incremental maintenance.
+* Creating explicit opportunities and invitations for community members to contribute larger lesson changes (Martino).
+* Exploring stronger links between SWC lessons and teaching-methods expertise within The Carpentries ecosystem.
+* Improving accessibility through review by people with lived accessibility needs and considering recognition mechanisms for contributors (Annajiat).
+* Including clearer pointers to continued learning, alternative tools, and workflows not covered in core lessons (Annajiat).
+
+
+### **4. Goals for the Next 3–5 Years**
+
+The committee discussed possible medium-term goals (dates tentative):
+
+* Draft and agree on a committee decision-making paradigm by **March 2026**, using consensus.
+* By **end of 2026**, adopt **2–3 intermediate lessons** from the Incubator into the official SWC curriculum, with at least one related to ML/AI.
+* Publish clear documentation explaining how curricula connect across SWC and The Carpentries.
+* Develop and publish a clear process for lesson adoption and maintenance.
+* By **end of 2026**, include Git hosting alternatives (e.g. GitLab) in the novice Git lesson, with discussion needed on maintenance models.
+* Explore inclusion of a graphical-interface-based Git lesson using free and open tools.
+* Improve accessibility of challenging lessons (e.g. shell) where possible.
+* Conduct an annual review of **3–5 lessons** to identify larger, strategic updates.
+* In **2027**, host a sprint focused on helping new contributors make substantive lesson improvements.
+
+Some ideas were noted as outside the committee’s direct mandate but appropriate to advocate for with the Core Team and Board.
+
+### **5. Term Lengths for Committee Members**
+
+The committee discussed whether to introduce recommended term lengths:
+
+* General agreement that having a defined cadence for check-ins would help avoid unintentional disengagement.
+* **Two-year terms** were broadly supported as a reasonable balance, with flexibility to step off earlier if needed.
+* Strong opposition to strict term limits; several members noted that long-term service can be mission-driven.
+* Discussion included staggered terms to preserve institutional memory and mechanisms for off-boarding and conflict management.
+* The importance of clear communication and transparency when capacity changes was emphasised.
+
+No final decision was made during the meeting.
+
+## **Action Items**
+
+* **Toby** to bring the discussion on term lengths back to the Library Carpentry Governance Committee and explore alignment across committees.
+* **All committee members** to review and asynchronously comment on the proposed 3–5 year goals, adding suggestions and refinements.
+
+## **Next Meeting**
+
+Date to be confirmed.


### PR DESCRIPTION
_Summary_

This pull request adds the minutes from the 16 Dec 2025 Software Carpentry Governance Committee meeting. 
It covers discussion notes, including some goals for the next 3–5 years.

Let me know if there's something not captured in here. Thanks a bunch!


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
